### PR TITLE
OMP changes

### DIFF
--- a/src/affine_sampler.h
+++ b/src/affine_sampler.h
@@ -730,10 +730,9 @@ TParallelAffineSampler<TParams, TLogger>::~TParallelAffineSampler() {
 
 template<class TParams, class TLogger>
 void TParallelAffineSampler<TParams, TLogger>::step(unsigned int N_steps, bool record_steps, double cycle, double p_replacement, double p_mixture, bool unbalanced) {
-	//omp_set_num_threads(N_samplers);
-	#pragma omp parallel firstprivate(record_steps, N_steps, cycle, p_replacement, p_mixture, unbalanced) num_threads(N_samplers)
+	#pragma omp parallel for firstprivate(record_steps, N_steps, cycle, p_replacement, p_mixture, unbalanced)
+	for(int thread_ID=0; thread_ID < N_samplers; thread_ID++)
 	{
-		unsigned int thread_ID = omp_get_thread_num();
 		double base_a = sampler[thread_ID]->get_scale();
 		for(unsigned int i=0; i<N_steps; i++) {
 			if(cycle > 1) {
@@ -788,9 +787,9 @@ void TParallelAffineSampler<TParams, TLogger>::calc_GR_transformed(std::vector<d
 		transf_stats[n] = new TStats(N);
 	}
 	
-	#pragma omp parallel num_threads(N_samplers)
+	#pragma omp parallel for
+	for(int n = 0; n < N_samplers; n++)
 	{
-		size_t n = omp_get_thread_num();
 		TStats& transf_comp_stat = *(transf_stats[n]);
 		TChain& chain = sampler[n]->get_chain();
 		size_t n_points = chain.get_length();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -244,7 +244,7 @@ int main(int argc, char **argv) {
 	 *  Execute
 	 */
 	
-	omp_set_num_threads(N_threads);
+	//omp_set_num_threads(N_threads);
 	
 	// Get list of pixels in input file
 	vector<unsigned int> healpix_index;


### PR DESCRIPTION
The OMP changes I made are here; pretty minimal.  OMP by default looks at OMP_NUM_THREADS for the number of threads it uses, so getting rid of the explicit omp_set_num_threads and using #pragma omp parallel for in place of #pragma omp parallel seems to do the trick.

What I wrote _doesn't_ seem to work if OMP_NUM_THREADS is greater than N_samplers, which I don't understand.  But in any case, for the simple situation of wanting it to run on only one core, and for your default situation of OMP_NUM_THREADS == N_samplers, behavior seems unchanged.
